### PR TITLE
chore(ci): upgrade to jenkins-packages-build-library@1.0.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,257 +1,75 @@
+library(
+    identifier: 'jenkins-packages-build-library@chore/add-rocky-single-pkg',
+    retriever: modernSCM([
+        $class: 'GitSCMSource',
+        remote: 'git@github.com:zextras/jenkins-packages-build-library.git',
+        credentialsId: 'jenkins-integration-with-github-account'
+    ])
+)
+
 pipeline {
     agent {
         node {
             label 'infra-v1'
         }
     }
-    parameters {
-        booleanParam defaultValue: false, description: 'Whether to upload the packages in playground repositories', name: 'PLAYGROUND'
-    }
+
     options {
         buildDiscarder(logRotator(numToKeepStr: '25'))
         timeout(time: 2, unit: 'HOURS')
         skipDefaultCheckout()
     }
+
+    parameters {
+        booleanParam defaultValue: false,
+            description: 'Whether to upload the packages in playground repositories',
+            name: 'PLAYGROUND'
+    }
+
+    tools {
+        jfrog 'jfrog-cli'
+    }
+
     stages {
         stage('Checkout') {
             steps {
                 checkout scm
                 script {
-                    env.GIT_COMMIT = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
-                }
-                stash includes: '**', name: 'project'
-            }
-        }
-        stage('Build deb/rpm') {
-            stages {
-                stage('yap') {
-                    parallel {
-                        stage('Ubuntu') {
-                            agent {
-                                node {
-                                    label 'yap-ubuntu-20-v1'
-                                }
-                            }
-                            steps {
-                                container('yap') {
-                                    unstash 'project'
-                                    script {
-                                        if (BRANCH_NAME == 'devel') {
-                                            def timestamp = new Date().format('yyyyMMddHHmmss')
-                                            sh "sudo yap build ubuntu package -r ${timestamp}"
-                                        } else {
-                                            sh 'sudo yap build ubuntu package'
-                                        }
-                                    }
-                                    stash includes: 'artifacts/', name: 'artifacts-deb'
-                                }
-                            }
-                            post {
-                                always {
-                                    archiveArtifacts artifacts: 'artifacts/*.deb', fingerprint: true
-                                }
-                            }
-                        }
-                        stage('RHEL') {
-                            agent {
-                                node {
-                                    label 'yap-rocky-8-v1'
-                                }
-                            }
-                            steps {
-                                container('yap') {
-                                    unstash 'project'
-                                    script {
-                                        if (BRANCH_NAME == 'devel') {
-                                            def timestamp = new Date().format('yyyyMMddHHmmss')
-                                            sh "sudo yap build rocky package -r ${timestamp}"
-                                        } else {
-                                            sh 'sudo yap build rocky package'
-                                        }
-                                    }
-                                    stash includes: 'artifacts/*.rpm', name: 'artifacts-rpm'
-                                }
-                            }
-                            post {
-                                always {
-                                    archiveArtifacts artifacts: 'artifacts/*.rpm', fingerprint: true
-                                }
-                            }
-                        }
-                    }
+                    gitMetadata()
                 }
             }
         }
-        stage('Upload To Playground') {
-            when {
-                anyOf {
-                    expression { params.PLAYGROUND == true }
-                }
-            }
+
+        stage('SonarQube analysis') {
             steps {
-                unstash 'artifacts-deb'
-                unstash 'artifacts-rpm'
                 script {
-                    def server = Artifactory.server 'zextras-artifactory'
-                    def buildInfo
-                    def uploadSpec
-                    buildInfo = Artifactory.newBuildInfo()
-                    uploadSpec = """{
-                        "files": [
-                            {
-                                "pattern": "artifacts/*.deb",
-                                "target": "ubuntu-playground/pool/",
-                                "props": "deb.distribution=focal;deb.distribution=jammy;deb.distribution=noble;deb.component=main;deb.architecture=amd64;vcs.revision=${env.GIT_COMMIT}"
-                            },
-                            {
-                                "pattern": "artifacts/(carbonio-timezone-data)-(*).x86_64.rpm",
-                                "target": "centos8-playground/zextras/{1}/{1}-{2}.x86_64.rpm",
-                                "props": "rpm.metadata.arch=x86_64;rpm.metadata.vendor=zextras;vcs.revision=${env.GIT_COMMIT}"
-                            },
-                            {
-                                "pattern": "artifacts/(carbonio-timezone-data)-(*).x86_64.rpm",
-                                "target": "rhel9-playground/zextras/{1}/{1}-{2}.x86_64.rpm",
-                                "props": "rpm.metadata.arch=x86_64;rpm.metadata.vendor=zextras;vcs.revision=${env.GIT_COMMIT}"
-                            }
-                        ]
-                    }"""
-                    server.upload spec: uploadSpec, buildInfo: buildInfo, failNoOp: false
+                    scannerHome = tool 'SonarScanner'
+                }
+                withSonarQubeEnv(credentialsId: 'sonarqube-user-token',
+                    installationName: 'SonarQube instance') {
+                    sh "${scannerHome}/bin/sonar-scanner"
                 }
             }
         }
-        stage('Upload To Devel') {
-            when {
-                branch 'devel'
-            }
+
+        stage('Build') {
             steps {
-                unstash 'artifacts-deb'
-                unstash 'artifacts-rpm'
-                script {
-                    def server = Artifactory.server 'zextras-artifactory'
-                    def buildInfo
-                    def uploadSpec
-                    buildInfo = Artifactory.newBuildInfo()
-                    uploadSpec = """{
-                        "files": [
-                            {
-                                "pattern": "artifacts/*.deb",
-                                "target": "ubuntu-devel/pool/",
-                                "props": "deb.distribution=focal;deb.distribution=jammy;deb.distribution=noble;deb.component=main;deb.architecture=amd64;vcs.revision=${env.GIT_COMMIT}"
-                            },
-                            {
-                                "pattern": "artifacts/(carbonio-timezone-data)-(*).x86_64.rpm",
-                                "target": "centos8-devel/zextras/{1}/{1}-{2}.x86_64.rpm",
-                                "props": "rpm.metadata.arch=x86_64;rpm.metadata.vendor=zextras;vcs.revision=${env.GIT_COMMIT}"
-                            },
-                            {
-                                "pattern": "artifacts/(carbonio-timezone-data)-(*).x86_64.rpm",
-                                "target": "rhel9-devel/zextras/{1}/{1}-{2}.x86_64.rpm",
-                                "props": "rpm.metadata.arch=x86_64;rpm.metadata.vendor=zextras;vcs.revision=${env.GIT_COMMIT}"
-                            }
-                        ]
-                    }"""
-                    server.upload spec: uploadSpec, buildInfo: buildInfo, failNoOp: false
-                }
+                echo 'Building deb/rpm packages'
+                buildStage([
+                    ubuntuSinglePkg: true,
+                    rockySinglePkg: true,
+                ])
             }
         }
-        stage('Upload & Promotion Config') {
-            when {
-                anyOf {
-                    branch 'release/*'
-                    buildingTag()
-                }
-            }
+
+        stage('Upload artifacts')
+        {
             steps {
-                unstash 'artifacts-deb'
-                unstash 'artifacts-rpm'
-                script {
-                    def server = Artifactory.server 'zextras-artifactory'
-                    def buildInfo
-                    def uploadSpec
-                    def config
-
-                    //ubuntu
-                    buildInfo = Artifactory.newBuildInfo()
-                    buildInfo.name += "-ubuntu"
-                    uploadSpec = """{
-                        "files": [
-                            {
-                                "pattern": "artifacts/*.deb",
-                                "target": "ubuntu-rc/pool/",
-                                "props": "deb.distribution=focal;deb.distribution=jammy;deb.distribution=noble;deb.component=main;deb.architecture=amd64;vcs.revision=${env.GIT_COMMIT}"
-                            }
-                        ]
-                    }"""
-                    server.upload spec: uploadSpec, buildInfo: buildInfo, failNoOp: false
-                    config = [
-                            'buildName'          : buildInfo.name,
-                            'buildNumber'        : buildInfo.number,
-                            'sourceRepo'         : 'ubuntu-rc',
-                            'targetRepo'         : 'ubuntu-release',
-                            'comment'            : 'Do not change anything! Just press the button',
-                            'status'             : 'Released',
-                            'includeDependencies': false,
-                            'copy'               : true,
-                            'failFast'           : true
-                    ]
-                    Artifactory.addInteractivePromotion server: server, promotionConfig: config, displayName: "Ubuntu Promotion to Release"
-                    server.publishBuildInfo buildInfo
-
-
-                    //rhel8
-                    buildInfo = Artifactory.newBuildInfo()
-                    buildInfo.name += "-centos8"
-                    uploadSpec= """{
-                        "files": [
-                            {
-                                "pattern": "artifacts/(carbonio-timezone-data)-(*).x86_64.rpm",
-                                "target": "centos8-rc/zextras/{1}/{1}-{2}.x86_64.rpm",
-                                "props": "rpm.metadata.arch=x86_64;rpm.metadata.vendor=zextras;vcs.revision=${env.GIT_COMMIT}"
-                            }
-                        ]
-                    }"""
-                    server.upload spec: uploadSpec, buildInfo: buildInfo, failNoOp: false
-                    config = [
-                            'buildName'          : buildInfo.name,
-                            'buildNumber'        : buildInfo.number,
-                            'sourceRepo'         : 'centos8-rc',
-                            'targetRepo'         : 'centos8-release',
-                            'comment'            : 'Do not change anything! Just press the button',
-                            'status'             : 'Released',
-                            'includeDependencies': false,
-                            'copy'               : true,
-                            'failFast'           : true
-                    ]
-                    Artifactory.addInteractivePromotion server: server, promotionConfig: config, displayName: "Centos8 Promotion to Release"
-                    server.publishBuildInfo buildInfo
-
-                    //rhel9
-                    buildInfo = Artifactory.newBuildInfo()
-                    buildInfo.name += "-rhel9"
-                    uploadSpec= """{
-                        "files": [
-                            {
-                                "pattern": "artifacts/(carbonio-timezone-data)-(*).x86_64.rpm",
-                                "target": "rhel9-rc/zextras/{1}/{1}-{2}.x86_64.rpm",
-                                "props": "rpm.metadata.arch=x86_64;rpm.metadata.vendor=zextras;vcs.revision=${env.GIT_COMMIT}"
-                            }
-                        ]
-                    }"""
-                    server.upload spec: uploadSpec, buildInfo: buildInfo, failNoOp: false
-                    config = [
-                            'buildName'          : buildInfo.name,
-                            'buildNumber'        : buildInfo.number,
-                            'sourceRepo'         : 'rhel9-rc',
-                            'targetRepo'         : 'rhel9-release',
-                            'comment'            : 'Do not change anything! Just press the button',
-                            'status'             : 'Released',
-                            'includeDependencies': false,
-                            'copy'               : true,
-                            'failFast'           : true
-                    ]
-                    Artifactory.addInteractivePromotion server: server, promotionConfig: config, displayName: "Centos8 Promotion to Release"
-                    server.publishBuildInfo buildInfo
-                }
+                uploadStage(
+                    packages: yapHelper.getPackageNames(),
+                    ubuntuSinglePkg: true,
+                    rockySinglePkg: true,
+                )
             }
         }
     }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,11 @@
+# must be unique in a given SonarQube instance
+sonar.projectKey=zextras:carbonio-timezone-data
+# this is the name and version displayed in the SonarQube UI. Was mandatory prior to SonarQube 6.1.
+sonar.projectName=carbonio-timezone-data
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+# This property is optional if sonar.modules is set.
+sonar.sources=.
+
+sonar.shell.file.suffixes=*.sh,src/bin/*
+sonar.exclusions=**/*.java,**/*.cnf,**/*.json,**/*.patch,**/*.hcl,**/*.service,**/*.m4,**/*.properties

--- a/yap.json
+++ b/yap.json
@@ -1,11 +1,11 @@
 {
     "name": "An open-source, community-driven email server",
-    "Description": "Timezone Data",
+    "description": "Timezone Data",
     "buildDir": "/tmp/",
     "output": "artifacts",
-    "Projects": [
+    "projects": [
         {
-            "name": "timezone-data"
+            "name": "package/timezone-data"
         }
     ]
 }


### PR DESCRIPTION
This PR updates the Jenkins pipeline to use the newly released jenkins-packages-build-library v1.0.2, which introduces major improvements to our build infrastructure:

Key Benefits:

1. reduce duplicated code
2. centralized configuration for supported platforms (ubuntu-jammy, ubuntu-noble etc.)
3. reutilize the playground rt project to test the pipeline release flow

These changes significantly reduce pipeline complexity while making builds more maintainable and reliable across all Zextras repositories.

Refs: IN-930 IN-908