### PR TITLE
chore: bump jenkins-lib-common to 1.7.5

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@1.7.3',
+    identifier: 'jenkins-lib-common@1.7.5',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',
@@ -69,4 +69,3 @@ pipeline {
         }
     }
 }
-


### PR DESCRIPTION
## Summary

- Bump `jenkins-lib-common` from current version to `1.7.5` in `Jenkinsfile`
- Part of JFrog cost optimization initiative (IN-1095)