### PR TITLE
feat(packaging): use arch=('any') for architecture-independent package

### DIFF
--- a/package/timezone-data/PKGBUILD
+++ b/package/timezone-data/PKGBUILD
@@ -1,7 +1,7 @@
 pkgname="carbonio-timezone-data"
 pkgver="4.0.9"
 pkgrel="1"
-arch=('x86_64')
+arch=('any')
 pkgdesc="Carbonio Timezone Data"
 maintainer="Zextras <packages@zextras.com>"
 copyright=(


### PR DESCRIPTION
## Summary

- Replace `arch=('x86_64')` with `arch=('any')` in PKGBUILD since this package does not contain architecture-specific binaries

IN-951