### PR TITLE
chore(ci): sync jenkins-lib-common updates from devel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build/
 .settings/
 .idea/
 *.iml
+.metals
+.vscode

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@1.7.0',
+    identifier: 'jenkins-lib-common@1.7.3',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@1.3.1',
+    identifier: 'jenkins-lib-common@1.3.4',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@1.3.4',
+    identifier: 'jenkins-lib-common@1.4.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@1.6.2',
+    identifier: 'jenkins-lib-common@1.7.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@1.5.0',
+    identifier: 'jenkins-lib-common@1.6.2',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@1.4.0',
+    identifier: 'jenkins-lib-common@1.5.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@1.7.3',
+    identifier: 'jenkins-lib-common@1.7.5',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',
@@ -69,4 +69,3 @@ pipeline {
         }
     }
 }
-

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,9 +26,7 @@ pipeline {
         stage('Setup') {
             steps {
                 checkout scm
-                script {
-                    gitMetadata()
-                }
+                gitMetadata()
             }
         }
 
@@ -40,6 +38,14 @@ pipeline {
                 withSonarQubeEnv(credentialsId: 'sonarqube-user-token',
                     installationName: 'SonarQube instance') {
                     sh "${scannerHome}/bin/sonar-scanner"
+                }
+            }
+        }
+
+        stage('Bump version') {
+            steps {
+                script {
+                    dt2_semanticRelease()
                 }
             }
         }

--- a/package/timezone-data/PKGBUILD
+++ b/package/timezone-data/PKGBUILD
@@ -1,7 +1,7 @@
 pkgname="carbonio-timezone-data"
 pkgver="4.0.9"
 pkgrel="1"
-arch=('x86_64')
+arch=('any')
 pkgdesc="Carbonio Timezone Data"
 maintainer="Zextras <packages@zextras.com>"
 copyright=(

--- a/package/timezone-data/PKGBUILD
+++ b/package/timezone-data/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-timezone-data"
-pkgver="4.0.9"
+pkgver="4.1.0"
 pkgrel="1"
 arch=('any')
 pkgdesc="Carbonio Timezone Data"

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
+export default {
+  branches: ['devel'],
+  tagFormat: "${version}",
+  plugins: [
+    [
+      '@semantic-release/commit-analyzer',
+      {
+        preset: 'conventionalcommits',
+        releaseRules: [
+          // enable release also for refactor and build commits
+          { type: 'refactor', release: 'patch' },
+          { type: 'build', release: 'patch' },
+          { type: 'ci', release: 'patch' },
+          { type: 'chore', 'scope': 'release', 'release': false},
+          { type: 'perf', release: 'patch' }
+        ]
+      }
+    ],
+    [
+      '@semantic-release/release-notes-generator',
+      {
+        preset: 'conventionalcommits',
+        presetConfig: {
+          // see https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.2.0/README.md#types
+          types: [
+            {
+              type: 'feat',
+              section: 'Features',
+              hidden: false
+            },
+            {
+              type: 'fix',
+              section: 'Bug Fixes',
+              hidden: false
+            },
+            {
+              type: 'refactor',
+              section: 'Other changes',
+              hidden: false
+            },
+            {
+              type: 'perf',
+              section: 'Other changes',
+              hidden: false
+            },
+            {
+              type: 'build',
+              section: 'Other changes',
+              hidden: false
+            },
+            {
+              type: 'ci',
+              section: 'Other changes',
+              hidden: false
+            }
+          ]
+        }
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "sed -i 's/^pkgver=.*/pkgver=\"${nextRelease.version}\"/' package/timezone-data/PKGBUILD"
+      }
+    ],
+    [
+      '@semantic-release/git',
+      {
+        assets: ['package/timezone-data/PKGBUILD'],
+        message: 'chore(release): ${nextRelease.version} [skip ci]'
+      }
+    ],
+    '@semantic-release/github'
+  ]
+};


### PR DESCRIPTION
Merges 12 commits from `devel` into `main`, bringing CI tooling up to date.

## Changes

- Bump `jenkins-lib-common` from v1.3.1 → v1.7.5 (via renovate + manual bumps)
- Add renovate configuration for automated dependency updates
- Move `defaultPipelineProperties` to top-level scope in Jenkinsfile