### PR TITLE
chore(deps)!: migrate to jenkins-lib-common v4.1.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@v2.11.2',
+    identifier: 'jenkins-lib-common@v4.1.4',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',


### PR DESCRIPTION
Migrates the `jenkins-lib-common` pin from `v2.11.2` to `v4.1.4`.

## Breaking changes considered

- **trunk-based branch guards** (`cd7c38c`, v2.0.0): already past this tag on the current pin — no behaviour change.
- **DinD -> Buildah** (`9b02055`, v2.10.0): already past this tag; this pipeline has no raw `docker`/`withDockerRegistry` calls, so nothing to touch either way.
- **`gitleaksStage` runs in the current pod** (`95d2559`, v3.0.0): **applies**. This job runs on `agent { label 'infra-v1' }` and calls `gitleaksStage()` — the `infra-v1` pod template had no `gitleaks` container, which would have broken this build. Fixed by zextras/infra-k3s#272 (merged), which adds the missing `gitleaks` container to `infra-v1`.
- **`mavenStage` parameter purge** (v4.0.0): N/A, not a Maven project.
- **`uploadStage(packages:)` removal**: N/A, `uploadStage` here only uses `ubuntuSinglePkg`/`rockySinglePkg`.
- **`uiPipeline(testScript:)` removal**: N/A, no `uiPipeline` usage.

## Merge gate

**Do not merge** until it is confirmed that the JCasC change in zextras/infra-k3s#272 has actually been synced/applied to the live Jenkins controller (ArgoCD app `jenkins` has `syncPolicy.automated`, so this should happen automatically, but it is not independently confirmable from this tooling — Jenkins itself is SSO-gated). Merging before that is confirmed would break this job's Security Scan stage (no `gitleaks` container in the pod it runs on).

Ref: https://zextras.atlassian.net/browse/IN-1168